### PR TITLE
Improve DIP

### DIFF
--- a/src/inliner.ml
+++ b/src/inliner.ml
@@ -37,3 +37,17 @@ let linear_mapper =
 
 let linear exp =
   linear_mapper.expr linear_mapper exp
+
+let remove_trivial_let_mapper =
+  { default_mapper with
+    expr = fun mapper expr ->
+           match expr with
+           | { pexp_desc =
+                 Pexp_let (Nonrecursive,
+                           [{pvb_pat = {ppat_desc = Ppat_tuple []};
+                             pvb_expr ={pexp_desc = Pexp_tuple []};}],
+                           body) } -> body
+           | other -> default_mapper.expr mapper other }
+
+let remove_trivial_let exp =
+  remove_trivial_let_mapper.expr remove_trivial_let_mapper exp

--- a/src/main.ml
+++ b/src/main.ml
@@ -7,7 +7,7 @@ let rec read_eval_print () =
   print_string "open Inst\n";
   print_string "let main param_st =\n";
   prerr_string (Pprintast.string_of_expression exp);
-  print_string (Pprintast.string_of_expression (Inliner.linear exp));
+  print_string (Pprintast.string_of_expression (Inliner.remove_trivial_let (Inliner.linear exp)));
   print_newline ()
 
 let _ = read_eval_print ()


### PR DESCRIPTION
At the end of DIP, only the variables introduced in the block will be returned to the continuation.  It simplifies code generated from DIP with only stack manipulating instructions.  Generated code often includes `let () = () in` when the body of DIP doesn't generate any new values, so an AST mapper to remove such trivial `let`s is also implemented.