### PR TITLE
LAMBDA and EXEC

### DIFF
--- a/src/mcParser.mly
+++ b/src/mcParser.mly
@@ -38,6 +38,7 @@ SingleInst :
   | m=MNEMONIC Ty b=BOOL { SimpleArgCon (m, Exp.construct (Location.mknoloc (Longident.Lident (string_of_bool b))) None) }
   | m=MNEMONIC i=INTV { SimpleWithNum (m, int_of_string i) }
   | m=MNEMONIC LBRACE is=InstList RBRACE { OneBlock (m, is) }
+  | m=MNEMONIC ty1=Ty ty2=Ty LBRACE is=InstList RBRACE { OneBlockWithTwoTys (m, ty1, ty2, is) }
   | m=MNEMONIC i=INTV LBRACE is=InstList RBRACE { OneBlockWithNum (m, int_of_string i, is) }
   | m=MNEMONIC LBRACE is1=InstList RBRACE LBRACE is2=InstList RBRACE { TwoBlocks (m, is1, is2) }
   | m=MNEMONIC error { prerr_string m; exit 1 }

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -6,6 +6,7 @@ type inst =
   | SimpleWithNum of string * int
   | OneBlock of string * inst list  (* such as DIP code *)
   | OneBlockWithNum of string * int * inst list  (* such as DIP 3 code *)
+  | OneBlockWithTwoTys of string * Parsetree.core_type * Parsetree.core_type * inst list  (* such as LAMBDA ty ty code *)
   | TwoBlocks of string * inst list * inst list  (* such IF code1 code 2 *)
 
 type program = 

--- a/test/inst.mli
+++ b/test/inst.mli
@@ -4,6 +4,7 @@ type 'a set
 type ('a, 'b) pair = 'a * 'b
 type ('k, 't) map
 type ('k, 't) big_map = ('k, 't) map
+type ('a, 'b) lambda
 
 val failwith : 'a -> 'b
 
@@ -51,6 +52,10 @@ val car : 'a * 'b -> 'a
 val cdr : 'a * 'b -> 'b
 val pair : 'a -> 'b -> ('a, 'b) pair
 val unpair : ('a, 'b) pair -> 'a * 'b
+
+(* Operations on lambda *)
+val lambda : ('a -> 'b) -> ('a, 'b) lambda
+val exec : 'a -> ('a, 'b) lambda -> 'b
 
 (* Operations on maps *)
 val empty_map : ('k, 'v) map


### PR DESCRIPTION
Implement `LAMBDA` and `EXEC`.

Type annotation for `LAMBDA` is parsed and put into the generated `fun`ction.