### PR TITLE
Address #8 (in a way not ideal).

### DIFF
--- a/src/trans.ml
+++ b/src/trans.ml
@@ -135,7 +135,7 @@ let rec exp_of_prog kont = function
      begin match final_vars with
        Some (var2 :: final_vars) ->
         assert(List.length vars_for_body = List.length final_vars);
-        let updated_vars = diff final_vars vars_for_body in
+        let updated_vars = final_vars in  (* used to be: diff final_vars vars_for_body, which is wrong ;-) *)
         let n = List.length updated_vars in
         let body = kond_is (Exp.tuple [exp_of_var var2; exp_of_tuple_vars updated_vars]) in
         let fun_ = Exp.fun_ Asttypes.Nolabel None
@@ -247,7 +247,7 @@ let rec exp_of_prog kont = function
      begin match final_vars with
        Some (var2 :: final_vars) ->
         assert(List.length vars_for_body = List.length final_vars);
-        let updated_vars = diff final_vars vars_for_body in
+        let updated_vars = final_vars in   (* used to be: diff final_vars vars_for_body, which is wrong ;-) *)
         let n = List.length updated_vars in
         let fun_ = Exp.fun_ Asttypes.Nolabel None
                      (Pat.tuple [pat_of_var var1; pat_of_tuple_vars (take n vars_for_body)])


### PR DESCRIPTION
It should be possible to save the number of variables to be passed to the body of `MAP` but for the present we give up.  So, _all_ the variables on the stack will be passed to the function representing the body of `MAP`.