### PR TITLE
Fix a bug in MAP.

### DIFF
--- a/src/mySupport.ml
+++ b/src/mySupport.ml
@@ -22,6 +22,14 @@ let let_ ids rhs body =
        pvb_loc = Location.none } ]
     body
 
+let letp_ pat rhs body =
+  Exp.let_ Asttypes.Nonrecursive
+    [ { pvb_pat  = pat;
+        pvb_expr = rhs;
+        pvb_attributes = [];
+       pvb_loc = Location.none } ]
+    body
+
 let call id ids =
   match ids with
     [] -> exp_of_var id

--- a/src/trans.ml
+++ b/src/trans.ml
@@ -187,7 +187,7 @@ let rec exp_of_prog kont = function
                      (Pat.tuple [pat_of_var var1; pat_of_tuple_vars parameters_for_body]) body in
         let var3 = newVar () in
         exp_of_prog
-          (fun expr -> kont (let_ (var3 :: let_bound_vars)
+          (fun expr -> kont (letp_ (Pat.tuple [pat_of_var var3; pat_of_tuple_vars let_bound_vars])
                                (Exp.apply (exp_of_var "map_list")
                                   [Asttypes.Nolabel, fun_;
                                    Asttypes.Nolabel,

--- a/test/KT18fp5rcTW7mbWDmzFwjLDUhs5MeJmagDSZ.tz
+++ b/test/KT18fp5rcTW7mbWDmzFwjLDUhs5MeJmagDSZ.tz
@@ -1,0 +1,779 @@
+parameter (or
+            (or
+              (or %admin
+                (pair %create_token (nat %token_id) (map %token_info string bytes))
+                (or %token_admin
+                  (or (unit %confirm_admin)
+                      (list %pause (pair (nat %token_id) (bool %paused))))
+                  (or (address %set_admin) (address %set_minter))))
+              (or %assets
+                (or
+                  (pair %balance_of
+                    (list %requests (pair (address %owner) (nat %token_id)))
+                    (contract %callback (list (pair
+                                              (pair %request (address %owner)
+                                                             (nat %token_id))
+                                              (nat %balance)))))
+                  (list %transfer (pair (address %from_)
+                                       (list %txs (pair (address %to_)
+                                                       (pair (nat %token_id)
+                                                             (nat %amount)))))))
+                (list %update_operators (or
+                                         (pair %add_operator (address %owner)
+                                                             (pair (address %operator)
+                                                                   (nat %token_id)))
+                                         (pair %remove_operator (address %owner)
+                                                                (pair
+                                                                  (address %operator)
+                                                                  (nat %token_id)))))))
+            (or %tokens
+              (list %burn_tokens (pair (address %owner)
+                                      (pair (nat %token_id) (nat %amount))))
+              (list %mint_tokens (pair (address %owner)
+                                      (pair (nat %token_id) (nat %amount))))));
+storage (pair
+          (pair
+            (pair %admin (pair (address %admin) (address %minter))
+                         (pair (big_map %paused nat unit)
+                               (option %pending_admin address)))
+            (pair %assets
+              (pair (big_map %ledger (pair address nat) nat)
+                    (big_map %operators (pair address (pair address nat)) unit))
+              (pair
+                (big_map %token_metadata nat
+                                         (pair (nat %token_id)
+                                               (map %token_info string bytes)))
+                (big_map %token_total_supply nat nat))))
+          (big_map %metadata string bytes));
+code { PUSH string "FA2_TOKEN_UNDEFINED" ;
+       PUSH string "FA2_INSUFFICIENT_BALANCE" ;
+       LAMBDA
+         (pair (pair address address) (pair (big_map nat unit) (option address)))
+         (pair (pair address address) (pair (big_map nat unit) (option address)))
+         { DUP ;
+           CAR ;
+           CAR ;
+           SENDER ;
+           COMPARE ;
+           NEQ ;
+           IF { DROP ; PUSH string "NOT_AN_ADMIN" ; FAILWITH } {} } ;
+       LAMBDA
+         (pair (pair address nat) (big_map (pair address nat) nat))
+         nat
+         { UNPAIR ; GET ; IF_NONE { PUSH nat 0 } {} } ;
+       DUP ;
+       LAMBDA
+         (pair (lambda (pair (pair address nat) (big_map (pair address nat) nat)) nat)
+               (pair (pair address nat) (pair nat (big_map (pair address nat) nat))))
+         (big_map (pair address nat) nat)
+         { UNPAIR ;
+           SWAP ;
+           UNPAIR ;
+           UNPAIR ;
+           DIG 2 ;
+           UNPAIR ;
+           DIG 3 ;
+           DIG 3 ;
+           PAIR ;
+           DUP 3 ;
+           SWAP ;
+           DUP ;
+           DUG 2 ;
+           PAIR ;
+           DIG 4 ;
+           SWAP ;
+           EXEC ;
+           DIG 2 ;
+           ADD ;
+           PUSH nat 0 ;
+           SWAP ;
+           DUP ;
+           DUG 2 ;
+           COMPARE ;
+           EQ ;
+           IF
+             { DROP ; NONE nat ; SWAP ; UPDATE }
+             { DIG 2 ; SWAP ; SOME ; DIG 2 ; UPDATE } } ;
+       SWAP ;
+       APPLY ;
+       DUP 4 ;
+       DUP 3 ;
+       PAIR ;
+       LAMBDA
+         (pair
+           (pair (lambda (pair (pair address nat) (big_map (pair address nat) nat)) nat)
+                 string)
+           (pair (pair address nat) (pair nat (big_map (pair address nat) nat))))
+         (big_map (pair address nat) nat)
+         { UNPAIR ;
+           UNPAIR ;
+           DIG 2 ;
+           UNPAIR ;
+           UNPAIR ;
+           DIG 2 ;
+           UNPAIR ;
+           DIG 3 ;
+           DIG 3 ;
+           PAIR ;
+           DUP 3 ;
+           SWAP ;
+           DUP ;
+           DUG 2 ;
+           PAIR ;
+           DIG 4 ;
+           SWAP ;
+           EXEC ;
+           DIG 2 ;
+           SWAP ;
+           SUB ;
+           ISNAT ;
+           IF_NONE
+             { DROP 2 ; FAILWITH }
+             { DIG 3 ;
+               DROP ;
+               PUSH nat 0 ;
+               SWAP ;
+               DUP ;
+               DUG 2 ;
+               COMPARE ;
+               EQ ;
+               IF
+                 { DROP ; NONE nat ; SWAP ; UPDATE }
+                 { DIG 2 ; SWAP ; SOME ; DIG 2 ; UPDATE } } } ;
+       SWAP ;
+       APPLY ;
+       DIG 6 ;
+       UNPAIR ;
+       IF_LEFT
+         { DIG 6 ;
+           DROP ;
+           IF_LEFT
+             { DIG 2 ;
+               DROP ;
+               DIG 2 ;
+               DROP ;
+               DIG 2 ;
+               DROP ;
+               DIG 3 ;
+               DROP ;
+               IF_LEFT
+                 { DIG 2 ;
+                   DROP ;
+                   SWAP ;
+                   DUP ;
+                   DUG 2 ;
+                   CDR ;
+                   DUP 3 ;
+                   CAR ;
+                   CDR ;
+                   DIG 2 ;
+                   DUP ;
+                   CAR ;
+                   DUP 3 ;
+                   CDR ;
+                   CAR ;
+                   SWAP ;
+                   DUP ;
+                   DUG 2 ;
+                   GET ;
+                   IF_NONE
+                     { DUP 3 ;
+                       CDR ;
+                       CDR ;
+                       DUP 4 ;
+                       CDR ;
+                       CAR ;
+                       DIG 3 ;
+                       DUP 4 ;
+                       SWAP ;
+                       SOME ;
+                       SWAP ;
+                       UPDATE ;
+                       PAIR ;
+                       DUP 3 ;
+                       CAR ;
+                       PAIR ;
+                       DIG 2 ;
+                       CDR ;
+                       CDR ;
+                       PUSH nat 0 ;
+                       DIG 3 ;
+                       SWAP ;
+                       SOME ;
+                       SWAP ;
+                       UPDATE ;
+                       SWAP ;
+                       DUP ;
+                       DUG 2 ;
+                       CDR ;
+                       CAR ;
+                       PAIR ;
+                       SWAP ;
+                       CAR ;
+                       PAIR }
+                     { DROP 4 ; PUSH string "FA2_DUP_TOKEN_ID" ; FAILWITH } ;
+                   DIG 2 ;
+                   CAR ;
+                   CAR ;
+                   PAIR ;
+                   PAIR ;
+                   NIL operation ;
+                   PAIR }
+                 { SWAP ;
+                   DUP ;
+                   DUG 2 ;
+                   CAR ;
+                   CAR ;
+                   SWAP ;
+                   IF_LEFT
+                     { IF_LEFT
+                         { DROP ;
+                           DIG 2 ;
+                           DROP ;
+                           DUP ;
+                           CDR ;
+                           CDR ;
+                           IF_NONE
+                             { DROP ; PUSH string "NO_PENDING_ADMIN" ; FAILWITH }
+                             { SENDER ;
+                               COMPARE ;
+                               EQ ;
+                               IF
+                                 { NONE address ;
+                                   SWAP ;
+                                   DUP ;
+                                   DUG 2 ;
+                                   CDR ;
+                                   CAR ;
+                                   PAIR ;
+                                   SWAP ;
+                                   CAR ;
+                                   CDR ;
+                                   SENDER ;
+                                   PAIR ;
+                                   PAIR }
+                                 { DROP ; PUSH string "NOT_A_PENDING_ADMIN" ; FAILWITH } } ;
+                           NIL operation ;
+                           PAIR }
+                         { SWAP ;
+                           DIG 3 ;
+                           SWAP ;
+                           EXEC ;
+                           DUP ;
+                           DUG 2 ;
+                           CDR ;
+                           CAR ;
+                           SWAP ;
+                           ITER { DUP ;
+                                  DUG 2 ;
+                                  CDR ;
+                                  IF
+                                    { UNIT ; DIG 2 ; CAR ; SWAP ; SOME ; SWAP ; UPDATE }
+                                    { SWAP ; CAR ; NONE unit ; SWAP ; UPDATE } } ;
+                           SWAP ;
+                           DUP ;
+                           DUG 2 ;
+                           CDR ;
+                           CDR ;
+                           SWAP ;
+                           PAIR ;
+                           SWAP ;
+                           CAR ;
+                           PAIR ;
+                           NIL operation ;
+                           PAIR } }
+                     { IF_LEFT
+                         { SWAP ;
+                           DIG 3 ;
+                           SWAP ;
+                           EXEC ;
+                           SWAP ;
+                           SOME ;
+                           SWAP ;
+                           DUP ;
+                           DUG 2 ;
+                           CDR ;
+                           CAR ;
+                           PAIR ;
+                           SWAP ;
+                           CAR ;
+                           PAIR ;
+                           NIL operation ;
+                           PAIR }
+                         { SWAP ;
+                           DIG 3 ;
+                           SWAP ;
+                           EXEC ;
+                           DUP ;
+                           CDR ;
+                           DUG 2 ;
+                           CAR ;
+                           CAR ;
+                           PAIR ;
+                           PAIR ;
+                           NIL operation ;
+                           PAIR } } ;
+                   UNPAIR ;
+                   DUP 3 ;
+                   CDR ;
+                   DIG 3 ;
+                   CAR ;
+                   CDR ;
+                   DIG 3 ;
+                   PAIR ;
+                   PAIR ;
+                   SWAP ;
+                   PAIR } }
+             { DIG 5 ;
+               DROP ;
+               DUP ;
+               DUP 3 ;
+               CAR ;
+               CAR ;
+               SWAP ;
+               IF_LEFT
+                 { IF_LEFT
+                     { DROP 2 ; UNIT }
+                     { SWAP ;
+                       CDR ;
+                       CAR ;
+                       SWAP ;
+                       ITER { CDR ;
+                              ITER { SWAP ;
+                                     DUP ;
+                                     DUG 2 ;
+                                     SWAP ;
+                                     CDR ;
+                                     CAR ;
+                                     MEM ;
+                                     IF { PUSH string "TOKEN_PAUSED" ; FAILWITH } {} } } ;
+                       DROP ;
+                       UNIT } }
+                 { DROP 2 ; UNIT } ;
+               DROP ;
+               SWAP ;
+               DUP ;
+               DUG 2 ;
+               CAR ;
+               CDR ;
+               SWAP ;
+               IF_LEFT
+                 { IF_LEFT
+                     { DIG 3 ;
+                       DROP ;
+                       DIG 3 ;
+                       DROP ;
+                       SWAP ;
+                       DUP ;
+                       DUG 2 ;
+                       CDR ;
+                       CAR ;
+                       DUP 3 ;
+                       CAR ;
+                       CAR ;
+                       DIG 2 ;
+                       DUP ;
+                       CAR ;
+                       MAP { DUP 4 ;
+                             SWAP ;
+                             DUP ;
+                             DUG 2 ;
+                             CDR ;
+                             MEM ;
+                             NOT ;
+                             IF
+                               { DROP ; DUP 7 ; FAILWITH }
+                               { DUP 3 ; SWAP ; DUP ; DUG 2 ; PAIR ; DUP 8 ; SWAP ; EXEC ; SWAP ; PAIR } } ;
+                       DIG 2 ;
+                       DROP ;
+                       DIG 2 ;
+                       DROP ;
+                       DIG 4 ;
+                       DROP ;
+                       DIG 4 ;
+                       DROP ;
+                       SWAP ;
+                       CDR ;
+                       PUSH mutez 0 ;
+                       DIG 2 ;
+                       TRANSFER_TOKENS ;
+                       SWAP ;
+                       NIL operation ;
+                       DIG 2 ;
+                       CONS ;
+                       PAIR }
+                     { DIG 5 ;
+                       DROP ;
+                       SWAP ;
+                       DUP ;
+                       DUG 2 ;
+                       LAMBDA
+                         (pair (pair address address)
+                               (pair nat
+                                     (big_map (pair address (pair address nat)) unit)))
+                         unit
+                         { UNPAIR ;
+                           UNPAIR ;
+                           DIG 2 ;
+                           UNPAIR ;
+                           DUP 4 ;
+                           DUP 4 ;
+                           COMPARE ;
+                           EQ ;
+                           IF
+                             { DROP 4 ; UNIT }
+                             { DIG 3 ;
+                               PAIR ;
+                               DIG 2 ;
+                               PAIR ;
+                               MEM ;
+                               IF
+                                 { UNIT }
+                                 { PUSH string "FA2_NOT_OPERATOR" ; FAILWITH } } } ;
+                       DIG 2 ;
+                       DUP 3 ;
+                       CAR ;
+                       CAR ;
+                       SWAP ;
+                       ITER { DUP ;
+                              DUG 2 ;
+                              CDR ;
+                              ITER { SWAP ;
+                                     DUP 5 ;
+                                     CDR ;
+                                     CAR ;
+                                     DUP 3 ;
+                                     CDR ;
+                                     CAR ;
+                                     MEM ;
+                                     NOT ;
+                                     IF
+                                       { DROP 2 ; DUP 8 ; FAILWITH }
+                                       { DUP 5 ;
+                                         CAR ;
+                                         CDR ;
+                                         DUP 3 ;
+                                         CDR ;
+                                         CAR ;
+                                         PAIR ;
+                                         SENDER ;
+                                         DUP 5 ;
+                                         CAR ;
+                                         PAIR ;
+                                         PAIR ;
+                                         DUP 5 ;
+                                         SWAP ;
+                                         EXEC ;
+                                         DROP ;
+                                         SWAP ;
+                                         DUP ;
+                                         DUG 2 ;
+                                         CDR ;
+                                         CDR ;
+                                         PAIR ;
+                                         SWAP ;
+                                         DUP ;
+                                         DUG 2 ;
+                                         CDR ;
+                                         CAR ;
+                                         DUP 4 ;
+                                         CAR ;
+                                         PAIR ;
+                                         PAIR ;
+                                         DUP 8 ;
+                                         SWAP ;
+                                         EXEC ;
+                                         SWAP ;
+                                         DUP ;
+                                         DUG 2 ;
+                                         CDR ;
+                                         CDR ;
+                                         PAIR ;
+                                         SWAP ;
+                                         DUP ;
+                                         DUG 2 ;
+                                         CDR ;
+                                         CAR ;
+                                         DIG 2 ;
+                                         CAR ;
+                                         PAIR ;
+                                         PAIR ;
+                                         DUP 8 ;
+                                         SWAP ;
+                                         EXEC } } ;
+                              SWAP ;
+                              DROP } ;
+                       SWAP ;
+                       DROP ;
+                       SWAP ;
+                       DROP ;
+                       DIG 3 ;
+                       DROP ;
+                       DIG 3 ;
+                       DROP ;
+                       DIG 3 ;
+                       DROP ;
+                       SWAP ;
+                       DUP ;
+                       DUG 2 ;
+                       CDR ;
+                       DIG 2 ;
+                       CAR ;
+                       CDR ;
+                       DIG 2 ;
+                       PAIR ;
+                       PAIR ;
+                       NIL operation ;
+                       PAIR } }
+                 { DIG 3 ;
+                   DROP ;
+                   DIG 3 ;
+                   DROP ;
+                   DIG 3 ;
+                   DROP ;
+                   DIG 3 ;
+                   DROP ;
+                   SWAP ;
+                   DUP ;
+                   DUG 2 ;
+                   CAR ;
+                   CDR ;
+                   SWAP ;
+                   SENDER ;
+                   DUG 2 ;
+                   ITER { SWAP ;
+                          DUP 3 ;
+                          DUP 3 ;
+                          IF_LEFT {} {} ;
+                          CAR ;
+                          COMPARE ;
+                          EQ ;
+                          IF {} { PUSH string "FA2_NOT_OWNER" ; FAILWITH } ;
+                          SWAP ;
+                          IF_LEFT
+                            { SWAP ;
+                              UNIT ;
+                              SOME ;
+                              DUP 3 ;
+                              CDR ;
+                              CDR ;
+                              DUP 4 ;
+                              CDR ;
+                              CAR ;
+                              PAIR ;
+                              DIG 3 ;
+                              CAR ;
+                              PAIR ;
+                              UPDATE }
+                            { DUP ;
+                              DUG 2 ;
+                              CDR ;
+                              CDR ;
+                              DUP 3 ;
+                              CDR ;
+                              CAR ;
+                              PAIR ;
+                              DIG 2 ;
+                              CAR ;
+                              PAIR ;
+                              NONE unit ;
+                              SWAP ;
+                              UPDATE } } ;
+                   SWAP ;
+                   DROP ;
+                   SWAP ;
+                   DUP ;
+                   DUG 2 ;
+                   CDR ;
+                   SWAP ;
+                   DIG 2 ;
+                   CAR ;
+                   CAR ;
+                   PAIR ;
+                   PAIR ;
+                   NIL operation ;
+                   PAIR } ;
+               UNPAIR ;
+               DUP 3 ;
+               CDR ;
+               DIG 2 ;
+               DIG 3 ;
+               CAR ;
+               CAR ;
+               PAIR ;
+               PAIR ;
+               SWAP ;
+               PAIR } }
+         { DIG 4 ;
+           DROP ;
+           DIG 4 ;
+           DROP ;
+           SWAP ;
+           DUP ;
+           DUG 2 ;
+           CAR ;
+           CAR ;
+           DUP ;
+           CAR ;
+           CDR ;
+           SENDER ;
+           COMPARE ;
+           NEQ ;
+           IF { DROP ; PUSH string "NOT_A_MINTER" ; FAILWITH } { DROP } ;
+           SWAP ;
+           DUP ;
+           DUG 2 ;
+           CAR ;
+           CDR ;
+           SWAP ;
+           IF_LEFT
+             { DIG 4 ;
+               DROP ;
+               SWAP ;
+               DUP ;
+               DUG 2 ;
+               CAR ;
+               CAR ;
+               SWAP ;
+               DUP ;
+               DUG 2 ;
+               ITER { DUP ;
+                      DUG 2 ;
+                      CDR ;
+                      CDR ;
+                      PAIR ;
+                      SWAP ;
+                      DUP ;
+                      DUG 2 ;
+                      CDR ;
+                      CAR ;
+                      DIG 2 ;
+                      CAR ;
+                      PAIR ;
+                      PAIR ;
+                      DUP 5 ;
+                      SWAP ;
+                      EXEC } ;
+               DIG 4 ;
+               DROP ;
+               DUP 3 ;
+               CDR ;
+               CDR ;
+               DIG 2 ;
+               ITER { SWAP ;
+                      DUP ;
+                      DUP 3 ;
+                      CDR ;
+                      CAR ;
+                      GET ;
+                      IF_NONE
+                        { DROP 2 ; DUP 5 ; FAILWITH }
+                        { DUP 3 ;
+                          CDR ;
+                          CDR ;
+                          SWAP ;
+                          SUB ;
+                          ISNAT ;
+                          IF_NONE { DUP 6 ; FAILWITH } {} ;
+                          SOME ;
+                          DIG 2 ;
+                          CDR ;
+                          CAR ;
+                          UPDATE } } ;
+               DIG 4 ;
+               DROP ;
+               DIG 4 ;
+               DROP ;
+               DUP 3 ;
+               CDR ;
+               DIG 3 ;
+               CAR ;
+               CDR ;
+               DIG 3 ;
+               PAIR ;
+               PAIR ;
+               DUP ;
+               DUG 2 ;
+               CDR ;
+               CAR ;
+               PAIR ;
+               SWAP ;
+               CAR ;
+               PAIR ;
+               NIL operation ;
+               PAIR }
+             { DIG 3 ;
+               DROP ;
+               DIG 4 ;
+               DROP ;
+               SWAP ;
+               DUP ;
+               DUG 2 ;
+               CAR ;
+               CAR ;
+               SWAP ;
+               DUP ;
+               DUG 2 ;
+               ITER { DUP ;
+                      DUG 2 ;
+                      CDR ;
+                      CDR ;
+                      PAIR ;
+                      SWAP ;
+                      DUP ;
+                      DUG 2 ;
+                      CDR ;
+                      CAR ;
+                      DIG 2 ;
+                      CAR ;
+                      PAIR ;
+                      PAIR ;
+                      DUP 5 ;
+                      SWAP ;
+                      EXEC } ;
+               DIG 4 ;
+               DROP ;
+               DUP 3 ;
+               CDR ;
+               CDR ;
+               DIG 2 ;
+               ITER { SWAP ;
+                      DUP ;
+                      DUP 3 ;
+                      CDR ;
+                      CAR ;
+                      GET ;
+                      IF_NONE
+                        { DROP 2 ; DUP 4 ; FAILWITH }
+                        { DUP 3 ; CDR ; CDR ; ADD ; SOME ; DIG 2 ; CDR ; CAR ; UPDATE } } ;
+               DIG 4 ;
+               DROP ;
+               DUP 3 ;
+               CDR ;
+               DIG 3 ;
+               CAR ;
+               CDR ;
+               DIG 3 ;
+               PAIR ;
+               PAIR ;
+               DUP ;
+               DUG 2 ;
+               CDR ;
+               CAR ;
+               PAIR ;
+               SWAP ;
+               CAR ;
+               PAIR ;
+               NIL operation ;
+               PAIR } ;
+           UNPAIR ;
+           DUP 3 ;
+           CDR ;
+           DIG 2 ;
+           DIG 3 ;
+           CAR ;
+           CAR ;
+           PAIR ;
+           PAIR ;
+           SWAP ;
+           PAIR } }


### PR DESCRIPTION
`MAP` should generate code of the following form:
```
let (x, (y1, ..., yn)) = map_list (fun (z, (w1, ..., wn)) -> ...)
```
but the current code generates
```
let (x, y1, ..., yn) = map_list (fun (z, (w1, ..., wn)) -> ...)
```
.  (Note the LHS of `let`)